### PR TITLE
fix: 스탬프 마크 위치 고정

### DIFF
--- a/src/components/Stamp/index.tsx
+++ b/src/components/Stamp/index.tsx
@@ -44,11 +44,13 @@ const Paper = ({ stageRef }: PaperProps) => {
         <KonvaImage
           key={`${index}-key`}
           image={stampMarkImage}
-          x={position.x - MARK_IMAGE_SIZE / 2}
-          y={position.y + 10 - MARK_IMAGE_SIZE / 2}
+          x={position.x}
+          y={position.y + 10}
           width={MARK_IMAGE_SIZE}
           height={MARK_IMAGE_SIZE}
           zIndex={10}
+          offsetX={MARK_IMAGE_SIZE / 2}
+          offsetY={MARK_IMAGE_SIZE / 2}
           rotation={position.rotation}
         />
       ))}


### PR DESCRIPTION
- 해결한 이슈 : https://github.com/song-ku-hae-hyeon/BTB/issues/44
- offset을 주어서 회전의 기준을 옮김.
- ant가 생성이 안되서 죽이는건 못해봄

![스탬프 이후](https://github.com/song-ku-hae-hyeon/BTB/assets/50704533/3e9c97dc-fdfb-4a41-b0b3-2ab1f3a9c162)
